### PR TITLE
Allocation improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!   let a: Box<[[[usize; 3]; 2]; 4]> = boxarray::boxarray_(f);
 //! ```
 use std::{
-    alloc::{alloc_zeroed, Layout},
+    alloc::{Layout, alloc},
     mem::transmute,
 };
 
@@ -166,7 +166,7 @@ pub use private::{Array, Value};
 ///
 pub fn boxarray<E: Clone, L: CUList, A: Arrays<E, L>>(e: E) -> Box<A> {
     unsafe {
-        let ptr = alloc_zeroed(Layout::new::<A>());
+        let ptr = alloc(Layout::new::<A>());
         let se = std::mem::size_of::<E>();
         if se != 0 {
             let st = std::mem::size_of::<A>();
@@ -232,7 +232,7 @@ pub fn boxarray_<E, L: CUList + IndexCoord<L>, A: Arrays<E, L>, F: Fn(CoordType<
     f: F,
 ) -> Box<A> {
     unsafe {
-        let ptr = alloc_zeroed(Layout::new::<A>());
+        let ptr = alloc(Layout::new::<A>());
         let se = std::mem::size_of::<E>();
         if se != 0 {
             let st = std::mem::size_of::<A>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ pub fn boxarray<E: Clone, L: CUList, A: Arrays<E, L>>(e: E) -> Box<A> {
             let n = st / se;
             let arr: *mut E = transmute(ptr);
             for i in 0..n {
-                *arr.add(i) = e.clone();
+                std::ptr::write(arr.add(i), e.clone());
             }
         }
         Box::from_raw(std::mem::transmute(ptr))
@@ -239,7 +239,7 @@ pub fn boxarray_<E, L: CUList + IndexCoord<L>, A: Arrays<E, L>, F: Fn(CoordType<
             let n = st / se;
             let arr: *mut E = transmute(ptr);
             for i in 0..n {
-                *arr.add(i) = f(L::coords(i));
+                std::ptr::write(arr.add(i), f(L::coords(i)));
             }
         }
         Box::from_raw(std::mem::transmute(ptr))


### PR DESCRIPTION
While doing some allocation profiling with [allocation_counter](https://crates.io/crates/allocation_counter) for some code of mine that uses boxarray, I noticed some strange behavior where the counter would report negative allocations. Putting aside the possibility that I'm simply a god-tier programmer and found a way to create more RAM for my OS from thin air, I dug into it a bit and found boxarray to be the culprit:

In situations where `E` (the array element type) is/contains a pointer, a program using the crate in its current form does this:
1. Allocs zeroed memory for the array (+1)
2. Allocs elements (+N)
3. *Assigns* those elements to the array's slots, which causes a drop of the old data, containing zeroed pointers (-N)
...
4. Drops elements in the array (-N)
5. Drops the array (-1)

This results in the weird net negative allocation count, and also worse performance as the memory has to be zeroed, and invalid zeroed pointers that will never contain data get deallocated.

This PR makes these changes:
- Changes `boxarray()` to use `std::ptr::write()`, which overwrites without dropping
- Changes `boxarray()` to alloc without zeroing, as it no longer relies on the safety of dropping zeroed pointers

<details>
<summary> Expand for repro & PR test code </summary>

```rs
/*
   [dependencies]
   allocation-counter = "0.8.1"
   boxarray_main = { package = "boxarray", git = "https://github.com/MuffinTastic/boxarray.git", branch = "main" }
   boxarray_pr = { package = "boxarray", git = "https://github.com/MuffinTastic/boxarray.git", branch = "MuffinTastic/alloc-improvements" }
*/

type ArrayType = [[[Box<u8>; 4]; 4]; 4];
const VALUE: u8 = 123;

#[inline(never)]
pub fn main_branch() {
    let array: Box<ArrayType> = boxarray_main::boxarray_(|_| Box::new(VALUE));

    assert_eq!(*array[0][0][0], VALUE);
}

#[inline(never)]
pub fn pr_branch() {
    let array: Box<ArrayType> = boxarray_pr::boxarray_(|_| Box::new(VALUE));

    assert_eq!(*array[0][0][0], VALUE);
}

pub fn run_x_times(f: impl Fn(), count: usize) -> std::time::Duration {
    let start = std::time::Instant::now();

    for _ in 0..count {
        f()
    }

    start.elapsed()
}

#[test]
fn run_benches() {
    let main_time = dbg!(run_x_times(main_branch, 100_000));
    let pr_time = dbg!(run_x_times(pr_branch, 100_000));
    let speed_improvement = main_time.as_secs_f64() / pr_time.as_secs_f64();
    println!("Speed improvement: {speed_improvement}x");

    /*
       [src/lib.rs:37:21] run_x_times(main_branch, 100_000) = 1.107311968s
       [src/lib.rs:38:19] run_x_times(pr_branch, 100_000) = 799.799782ms
       Speed improvement: 1.384486458887282x
    */
}

#[test]
fn measure_allocs() {
    use allocation_counter::measure;

    dbg!(measure(main_branch));
    dbg!(measure(pr_branch));

    /*
      [src/lib.rs:53:5] measure(main_branch) = AllocationInfo {
           count_total: 65,
           count_current: -64,
           count_max: 2,
           bytes_total: 576,
           bytes_current: -64,
           bytes_max: 513,
       }
       [src/lib.rs:54:5] measure(pr_branch) = AllocationInfo {
           count_total: 65,
           count_current: 0,
           count_max: 65,
           bytes_total: 576,
           bytes_current: 0,
           bytes_max: 576,
       }
    */
}
```    
</details>